### PR TITLE
Feature: filename in Spans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, stable, 1.84.1]
+        rust: [nightly, beta, stable, 1.84.1]
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
@@ -36,6 +36,7 @@ jobs:
         if: matrix.rust == 'nightly'
       - run: cargo build
       - run: cargo test
+      - run: cargo test --all-features
 
   doc:
     name: Documentation
@@ -59,6 +60,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@clippy
       - run: cargo clippy --tests -- -Dclippy::all
+      - run: cargo clippy --tests --all-features -- -Dclippy::all
 
   miri:
     name: Miri
@@ -70,7 +72,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@miri
       - run: cargo miri setup
-      - run: cargo miri test
+      - run: cargo miri test --all-features
         env:
           MIRIFLAGS: -Zmiri-strict-provenance
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.vscode/
 target
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ anyhow = "1.0.79"
 indoc = "2.0"
 serde_derive = "1.0.195"
 
+[features]
+filename = []
+
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 rustdoc-args = ["--generate-link-to-definition"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,11 @@ pub use crate::error::{Error, Location, Result};
 pub use crate::ser::{to_string, to_writer, Serializer};
 #[doc(inline)]
 pub use crate::spanned::{reset_marker, set_marker, Marker, Span, Spanned};
+
+#[cfg(feature = "filename")]
+#[doc(inline)]
+pub use crate::spanned::with_filename;
+
 #[doc(inline)]
 pub use crate::value::{from_value, to_value, Index, Number, Sequence, Value};
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -716,7 +716,7 @@ impl Value {
             | Value::Sequence(_, span)
             | Value::Mapping(_, span)
             | Value::Tagged(_, span)
-            | Value::String(_, span) => *span,
+            | Value::String(_, span) => span.clone(),
         }
     }
 
@@ -743,10 +743,18 @@ impl Value {
 
     fn broadcast_start_mark(&self) {
         spanned::set_marker(self.span().start);
+        #[cfg(feature = "filename")]
+        if let Some(filename) = self.span().filename {
+            spanned::set_filename(filename);
+        }
     }
 
     fn broadcast_end_mark(&self) {
         spanned::set_marker(self.span().end);
+        #[cfg(feature = "filename")]
+        if let Some(filename) = self.span().filename {
+            spanned::set_filename(filename);
+        }
     }
 }
 

--- a/tests/test_spanned.rs
+++ b/tests/test_spanned.rs
@@ -207,3 +207,31 @@ fn test_custom_deserialize_with() {
         y: Spanned<f64>,
     }
 }
+
+#[cfg(feature = "filename")]
+#[test]
+fn test_with_filename() {
+    use std::path::PathBuf;
+
+    use serde::de::IntoDeserializer as _;
+
+    let yaml = indoc! {"
+        x: 1.0
+        y: 2.0
+    "};
+
+    let value = {
+        let _f = dbt_serde_yaml::with_filename("filename.yml");
+        let value: dbt_serde_yaml::Value = dbt_serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(
+            dbg!(value.span()).filename.as_deref(),
+            Some(PathBuf::from("filename.yml")).as_ref()
+        );
+        dbt_serde_yaml::Value::deserialize(value.into_deserializer()).unwrap()
+    };
+
+    assert_eq!(
+        value.span().filename.as_deref(),
+        Some(PathBuf::from("filename.yml")).as_ref()
+    );
+}


### PR DESCRIPTION
This adds a `filename` feature flag: when enabled, `Span` will contain an additional field `filename`, which optionally stores a PathBuf. This allows deserialized `Value` and `Spanned` objects to be fully self-contained in regards to source location info.