### PR TITLE
Add `Verbatim` wrapper

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,8 @@ pub use crate::spanned::with_filename;
 
 #[doc(inline)]
 pub use crate::value::{from_value, to_value, Index, Number, Sequence, Value};
+#[doc(inline)]
+pub use crate::verbatim::Verbatim;
 
 #[doc(inline)]
 pub use crate::mapping::Mapping;
@@ -186,6 +188,7 @@ mod path;
 mod ser;
 pub mod spanned;
 pub mod value;
+mod verbatim;
 pub mod with;
 
 // Prevent downstream code from implementing the Index trait.

--- a/src/verbatim.rs
+++ b/src/verbatim.rs
@@ -1,0 +1,130 @@
+//! This module defines the `Verbatim` type, which is a wrapper type that can be
+//! used to in `#[derive(Deserialize)]` structs to protect fields from the
+//! `field_transfomer` when deserialized by the `Value::into_typed` method.
+
+use std::{
+    fmt::{self, Debug},
+    hash::Hash,
+    hash::Hasher,
+    ops::{Deref, DerefMut},
+};
+
+use serde::{de::IntoDeserializer, Deserialize, Deserializer, Serialize, Serializer};
+
+/// A wrapper type that protects the inner value from being transformed by the
+/// `field_transformer` when deserialized by the `Value::into_typed` method.
+pub struct Verbatim<T>(pub T);
+
+impl<T> Deref for Verbatim<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for Verbatim<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T> Clone for Verbatim<T>
+where
+    T: Clone,
+{
+    fn clone(&self) -> Self {
+        Verbatim(self.0.clone())
+    }
+}
+
+impl<T> Copy for Verbatim<T> where T: Copy {}
+
+impl<T> Debug for Verbatim<T>
+where
+    T: Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<T> PartialEq for Verbatim<T>
+where
+    T: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<T> Eq for Verbatim<T> where T: Eq {}
+
+impl<T> PartialOrd for Verbatim<T>
+where
+    T: PartialOrd,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.0.partial_cmp(&other.0)
+    }
+}
+
+impl<T> Ord for Verbatim<T>
+where
+    T: Ord,
+{
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl<T> Hash for Verbatim<T>
+where
+    T: Hash,
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.hash(state)
+    }
+}
+
+impl<T> Default for Verbatim<T>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        Verbatim(T::default())
+    }
+}
+
+impl<T> From<T> for Verbatim<T> {
+    fn from(value: T) -> Self {
+        Verbatim(value)
+    }
+}
+
+impl<T> Serialize for Verbatim<T>
+where
+    T: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de, T> Deserialize<'de> for Verbatim<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = crate::Value::deserialize(deserializer)?;
+        T::deserialize(value.into_deserializer())
+            .map(Verbatim)
+            .map_err(serde::de::Error::custom)
+    }
+}


### PR DESCRIPTION
The `Verbatim` wrapper type allows finer grained control over the behavior of `field_transfomer`, when deserializing a `#[derive(Deserialize)]` struct using `Value::into_typed`: when used, `Verbatim` exempts the wrapped value from being transformed by `field_transformer`.