### PR TITLE
Unify error location representation

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -642,7 +642,7 @@ impl<'de, 'document> DeserializerFromEvents<'de, 'document> {
         let previous_depth = self.remaining_depth;
         self.remaining_depth = match previous_depth.checked_sub(1) {
             Some(depth) => depth,
-            None => return Err(error::new(ErrorImpl::RecursionLimitExceeded(mark))),
+            None => return Err(error::new(ErrorImpl::RecursionLimitExceeded(mark.into()))),
         };
         let result = f(self);
         self.remaining_depth = previous_depth;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@
 )]
 
 pub use crate::de::{from_reader, from_slice, from_str, Deserializer};
-pub use crate::error::{Error, Location, Result};
+pub use crate::error::{Error, Result};
 pub use crate::ser::{to_string, to_writer, Serializer};
 #[doc(inline)]
 pub use crate::spanned::{reset_marker, set_marker, Marker, Span, Spanned};

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -95,7 +95,8 @@ impl<'input> Loader<'input> {
                 YamlEvent::Alias(alias) => match anchors.get(&alias) {
                     Some(id) => Event::Alias(*id),
                     None => {
-                        document.error = Some(error::new(ErrorImpl::UnknownAnchor(mark)).shared());
+                        document.error =
+                            Some(error::new(ErrorImpl::UnknownAnchor(mark.into())).shared());
                         return Some(document);
                     }
                 },

--- a/src/spanned/span.rs
+++ b/src/spanned/span.rs
@@ -56,13 +56,13 @@ impl Span {
 impl Span {
     /// Create a new span with the specified filename.
     pub fn new_with_filename(
-        start: Marker,
-        end: Marker,
+        start: impl Into<Marker>,
+        end: impl Into<Marker>,
         filename: impl Into<Arc<PathBuf>>,
     ) -> Self {
         Span {
-            start,
-            end,
+            start: start.into(),
+            end: end.into(),
             filename: Some(filename.into()),
         }
     }
@@ -124,6 +124,12 @@ impl From<Range<Option<Marker>>> for Span {
     }
 }
 
+impl From<Marker> for Span {
+    fn from(marker: Marker) -> Self {
+        Span::new(marker, marker)
+    }
+}
+
 /// A location in the source string.
 #[derive(Copy, Clone, PartialEq, PartialOrd)]
 pub struct Marker {
@@ -164,6 +170,21 @@ impl Marker {
             column: 0,
         }
     }
+
+    /// Return the line number of this location.
+    pub fn line(&self) -> usize {
+        self.line
+    }
+
+    /// Return the column number of this location.
+    pub fn column(&self) -> usize {
+        self.column
+    }
+
+    /// Return the index of this location.
+    pub fn index(&self) -> usize {
+        self.index
+    }
 }
 
 impl Default for Marker {
@@ -191,6 +212,6 @@ impl Debug for Marker {
 
 impl Display for Marker {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}:{}", self.line, self.column)
+        write!(f, "line {} column {}", self.line, self.column)
     }
 }

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -1,3 +1,4 @@
+use crate::error;
 use crate::mapping::{DuplicateKey, MappingVisitor};
 use crate::value::tagged::{self, TagStringVisitor};
 use crate::value::TaggedValue;
@@ -1411,9 +1412,9 @@ impl<'de> Deserializer<'de> for &'de Value {
                 value: None,
             },
             other => {
-                return Err(Error::invalid_type(
-                    other.unexpected(),
-                    &"a Value::Tagged enum",
+                return Err(error::set_span(
+                    Error::invalid_type(other.unexpected(), &"a Value::Tagged enum"),
+                    self.span(),
                 ));
             }
         })
@@ -1654,11 +1655,8 @@ impl<'de> Deserializer<'de> for MapRefDeserializer<'de> {
 
 impl Value {
     #[cold]
-    fn invalid_type<E>(&self, exp: &dyn Expected) -> E
-    where
-        E: de::Error,
-    {
-        de::Error::invalid_type(self.unexpected(), exp)
+    fn invalid_type(&self, exp: &dyn Expected) -> Error {
+        error::set_span(de::Error::invalid_type(self.unexpected(), exp), self.span())
     }
 
     #[cold]

--- a/tests/test_error.rs
+++ b/tests/test_error.rs
@@ -169,7 +169,7 @@ fn test_missing_enum_tag() {
         "V": 16
         "other": 32
     "#};
-    let expected = "invalid type: map, expected a YAML tag starting with '!'";
+    let expected = "invalid type: map, expected a YAML tag starting with '!' at line 1 column 1";
     test_error::<E>(yaml, expected);
 }
 
@@ -271,7 +271,7 @@ fn test_struct_from_sequence() {
     let yaml = indoc! {"
         [0, 0]
     "};
-    let expected = "invalid type: sequence, expected struct Struct";
+    let expected = "invalid type: sequence, expected struct Struct at line 1 column 1";
     test_error::<Struct>(yaml, expected);
 }
 
@@ -358,7 +358,7 @@ fn test_infinite_recursion_objects() {
     }
 
     let yaml = "&a {'x': *a}";
-    let expected = "recursion limit exceeded";
+    let expected = "recursion limit exceeded at line 1 column 1";
     test_error::<S>(yaml, expected);
 }
 
@@ -372,7 +372,7 @@ fn test_infinite_recursion_arrays() {
     );
 
     let yaml = "&a [0, *a]";
-    let expected = "recursion limit exceeded";
+    let expected = "recursion limit exceeded at line 1 column 1";
     test_error::<S>(yaml, expected);
 }
 
@@ -383,7 +383,7 @@ fn test_infinite_recursion_newtype() {
     pub struct S(#[allow(dead_code)] pub Option<Box<S>>);
 
     let yaml = "&a [*a]";
-    let expected = "recursion limit exceeded";
+    let expected = "recursion limit exceeded at line 1 column 1";
     test_error::<S>(yaml, expected);
 }
 


### PR DESCRIPTION
* Move to using `Span`/`Marker` in `Error`
* Fix an edge case where the location suffix is not printed in error messages when the location is 1:1