### PR TITLE
field_transformer: fix option handling

### DIFF
--- a/src/verbatim.rs
+++ b/src/verbatim.rs
@@ -131,17 +131,18 @@ pub(crate) fn should_transform_any() -> bool {
     SHOULD_TRANSFORM_ANY.with(|flag| flag.get())
 }
 
-pub(crate) struct ShouldTransformAnyGuard;
+struct ShouldTransformAnyGuard(bool);
 
 impl Drop for ShouldTransformAnyGuard {
     fn drop(&mut self) {
-        SHOULD_TRANSFORM_ANY.with(|flag| flag.set(true));
+        SHOULD_TRANSFORM_ANY.with(|flag| flag.set(self.0));
     }
 }
 
-pub(crate) fn with_should_not_transform_any() -> ShouldTransformAnyGuard {
+fn with_should_not_transform_any() -> ShouldTransformAnyGuard {
+    let current = SHOULD_TRANSFORM_ANY.with(|flag| flag.get());
     SHOULD_TRANSFORM_ANY.with(|flag| flag.set(false));
-    ShouldTransformAnyGuard
+    ShouldTransformAnyGuard(current)
 }
 
 thread_local! {

--- a/tests/test_spanned.rs
+++ b/tests/test_spanned.rs
@@ -224,7 +224,7 @@ fn test_with_filename() {
         let _f = dbt_serde_yaml::with_filename("filename.yml");
         let value: dbt_serde_yaml::Value = dbt_serde_yaml::from_str(yaml).unwrap();
         assert_eq!(
-            dbg!(value.span()).filename.as_deref(),
+            value.span().filename.as_deref(),
             Some(PathBuf::from("filename.yml")).as_ref()
         );
         dbt_serde_yaml::Value::deserialize(value.into_deserializer()).unwrap()


### PR DESCRIPTION
Avoid double-transforming the value when deserializing into an `Option<..>` target.