### PR TITLE
Implement special field `__flatten__`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -36,6 +36,7 @@ pub(crate) enum ErrorImpl {
     SequenceInMergeElement,
     EmptyTag,
     FailedToParseNumber,
+    FlattenNotMapping,
 
     External(Box<dyn StdError + 'static + Send + Sync>),
 
@@ -265,6 +266,11 @@ impl ErrorImpl {
             ErrorImpl::FailedToParseNumber => f.write_str("failed to parse YAML number"),
             ErrorImpl::External(err) => Display::fmt(err.as_ref(), f),
             ErrorImpl::Shared(_) => unreachable!(),
+            ErrorImpl::FlattenNotMapping => write!(
+                f,
+                "expected the {} field to be a mapping",
+                crate::value::FLATTEN_KEY
+            ),
         }
     }
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -826,3 +826,5 @@ impl IntoDeserializer<'_, Error> for Value {
         de::ValueDeserializer::new(self)
     }
 }
+
+pub(crate) const FLATTEN_KEY: &str = "__flatten__";

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -806,6 +806,18 @@ impl ser::SerializeStruct for SerializeStruct {
     where
         V: ?Sized + ser::Serialize,
     {
+        if key == super::FLATTEN_KEY {
+            let flattened = value.serialize(Serializer)?;
+            if let Value::Mapping(flattened, ..) = flattened {
+                for (k, v) in flattened {
+                    self.mapping.insert(k, v);
+                }
+                return Ok(());
+            } else {
+                return Err(error::new(ErrorImpl::FlattenNotMapping));
+            }
+        }
+
         self.mapping.insert(to_value(key)?, to_value(value)?);
         Ok(())
     }
@@ -828,6 +840,18 @@ impl ser::SerializeStructVariant for SerializeStructVariant {
     where
         V: ?Sized + ser::Serialize,
     {
+        if field == super::FLATTEN_KEY {
+            let flattened = v.serialize(Serializer)?;
+            if let Value::Mapping(flattened, ..) = flattened {
+                for (k, v) in flattened {
+                    self.mapping.insert(k, v);
+                }
+                return Ok(());
+            } else {
+                return Err(error::new(ErrorImpl::FlattenNotMapping));
+            }
+        }
+
         self.mapping.insert(to_value(field)?, to_value(v)?);
         Ok(())
     }


### PR DESCRIPTION
As a substitute for `serde[flatten]` that works with `Verbatim`.