### PR TITLE
Flatten any `__<NAME>__` struct fields

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -266,11 +266,7 @@ impl ErrorImpl {
             ErrorImpl::FailedToParseNumber => f.write_str("failed to parse YAML number"),
             ErrorImpl::External(err) => Display::fmt(err.as_ref(), f),
             ErrorImpl::Shared(_) => unreachable!(),
-            ErrorImpl::FlattenNotMapping => write!(
-                f,
-                "expected the {} field to be a mapping",
-                crate::value::FLATTEN_KEY
-            ),
+            ErrorImpl::FlattenNotMapping => write!(f, "expected the flatten field to be a mapping"),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,3 +200,11 @@ mod private {
     impl Sealed for crate::Value {}
     impl<T> Sealed for &T where T: ?Sized + Sealed {}
 }
+
+pub(crate) fn is_flatten_key(key: &[u8]) -> bool {
+    key.len() > 4
+        && key[0] == b'_'
+        && key[1] == b'_'
+        && key[key.len() - 2] == b'_'
+        && key[key.len() - 1] == b'_'
+}

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -826,5 +826,3 @@ impl IntoDeserializer<'_, Error> for Value {
         de::ValueDeserializer::new(self)
     }
 }
-
-pub(crate) const FLATTEN_KEY: &str = "__flatten__";

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -806,7 +806,7 @@ impl ser::SerializeStruct for SerializeStruct {
     where
         V: ?Sized + ser::Serialize,
     {
-        if key == super::FLATTEN_KEY {
+        if crate::is_flatten_key(key.as_bytes()) {
             let flattened = value.serialize(Serializer)?;
             if let Value::Mapping(flattened, ..) = flattened {
                 for (k, v) in flattened {
@@ -840,7 +840,7 @@ impl ser::SerializeStructVariant for SerializeStructVariant {
     where
         V: ?Sized + ser::Serialize,
     {
-        if field == super::FLATTEN_KEY {
+        if crate::is_flatten_key(field.as_bytes()) {
             let flattened = v.serialize(Serializer)?;
             if let Value::Mapping(flattened, ..) = flattened {
                 for (k, v) in flattened {

--- a/tests/test_value.rs
+++ b/tests/test_value.rs
@@ -560,7 +560,7 @@ fn test_verbatim_flatten() {
 }
 
 #[test]
-fn test_rest() {
+fn test_flatten() {
     #[derive(Deserialize, Serialize, PartialEq, Eq, Debug)]
     struct Thing3 {
         x: Option<i32>,
@@ -602,10 +602,24 @@ fn test_rest() {
         "})
         .unwrap()
     );
+
+    let value = dbt_serde_yaml::from_str::<Value>(indoc! {"
+        y: 2
+    "})
+    .unwrap();
+    let thing3 = Thing3::deserialize(value.into_deserializer()).unwrap();
+    assert_eq!(
+        thing3,
+        Thing3 {
+            x: None,
+            y: 2.into(),
+            __flatten__: HashMap::new()
+        }
+    );
 }
 
 #[test]
-fn test_verbatim_rest_nested() {
+fn test_verbatim_flatten_nested() {
     #[derive(Deserialize, PartialEq, Eq, Debug)]
     struct Thing4 {
         x: Option<i32>,

--- a/tests/test_value.rs
+++ b/tests/test_value.rs
@@ -623,13 +623,13 @@ fn test_verbatim_flatten_nested() {
     #[derive(Deserialize, PartialEq, Eq, Debug)]
     struct Thing4 {
         x: Option<i32>,
-        __flatten__: Verbatim<HashMap<String, Thing5>>,
+        __thing5__: Verbatim<HashMap<String, Thing5>>,
     }
 
     #[derive(Deserialize, PartialEq, Eq, Debug)]
     struct Thing5 {
         a: Option<i32>,
-        __flatten__: HashMap<String, Option<i32>>,
+        __rest__: HashMap<String, Option<i32>>,
     }
 
     let value = dbt_serde_yaml::from_str::<Value>(indoc! {"
@@ -654,12 +654,12 @@ fn test_verbatim_flatten_nested() {
         )
         .unwrap();
     assert_eq!(thing4.x, None);
-    assert_eq!(thing4.__flatten__.len(), 1);
+    assert_eq!(thing4.__thing5__.len(), 1);
     assert_eq!(
-        thing4.__flatten__["z"],
+        thing4.__thing5__["z"],
         Thing5 {
             a: Some(3),
-            __flatten__: HashMap::from([("b".to_string(), Some(4))]),
+            __rest__: HashMap::from([("b".to_string(), Some(4))]),
         }
     );
 }


### PR DESCRIPTION
Apply flattening to all fields that starts and ends with `__`