### PR TITLE
deserialize_option: use `visit_unit()` for None values

### DIFF
--- a/dbt-serde_yaml/src/de.rs
+++ b/dbt-serde_yaml/src/de.rs
@@ -1559,7 +1559,7 @@ impl<'de> de::Deserializer<'de> for &mut DeserializerFromEvents<'de, '_> {
         } else {
             *self.pos += 1;
             self.current_enum = None;
-            visitor.visit_none()
+            visitor.visit_unit()
         }
     }
 

--- a/dbt-serde_yaml/src/value/de.rs
+++ b/dbt-serde_yaml/src/value/de.rs
@@ -855,7 +855,7 @@ where
         let span = self.value.span();
         self.value.broadcast_end_mark();
         match self.value {
-            Value::Null(..) => visitor.visit_none(),
+            Value::Null(..) => visitor.visit_unit(),
             _ => visitor.visit_some(ValueDeserializer::<U, F> {
                 value: self.value,
                 unused_key_callback: self.unused_key_callback,
@@ -1745,7 +1745,7 @@ impl<'de> Deserializer<'de> for &'de Value {
         V: Visitor<'de>,
     {
         match self {
-            Value::Null(..) => visitor.visit_none(),
+            Value::Null(..) => visitor.visit_unit(),
             _ => visitor.visit_some(self),
         }
     }

--- a/dbt-serde_yaml/tests/test_value.rs
+++ b/dbt-serde_yaml/tests/test_value.rs
@@ -720,10 +720,10 @@ fn test_schemars() {
 
     #[derive(JsonSchema)]
     struct Thing {
-        x: Option<i32>,
+        x: Option<Option<i32>>,
         y: Verbatim<Value>,
         z: Verbatim<Option<Value>>,
-        v: Verbatim<Option<String>>,
+        v: Verbatim<Option<Option<String>>>,
     }
 
     let schema = schema_for!(Thing);


### PR DESCRIPTION
`#derive[(Deserialize)]` is (unfortunately) hard-coded to call `visit_none()` for missing fields (https://github.com/serde-rs/serde/blob/b426ff81e34ee12aa18305428922b75e3d83b51e/serde/src/private/de.rs#L47), so we will use `visit_unit()` for explicit Yaml `null` values, to allow `Deserialize` implementations to distinguish between `null` and "missing" fields.