### PR TITLE
Support path tracking for key callbacks

### DIFF
--- a/dbt-serde_yaml/src/libyaml/error.rs
+++ b/dbt-serde_yaml/src/libyaml/error.rs
@@ -18,29 +18,29 @@ pub(crate) struct Error {
 impl Error {
     pub unsafe fn parse_error(parser: *const sys::yaml_parser_t) -> Self {
         Error {
-            kind: unsafe { (*parser).error },
-            problem: match NonNull::new(unsafe { (*parser).problem as *mut _ }) {
+            kind: unsafe { (&(*parser)).error },
+            problem: match NonNull::new(unsafe { (&(*parser)).problem as *mut _ }) {
                 Some(problem) => unsafe { CStr::from_ptr(problem) },
                 None => CStr::from_bytes_with_nul(b"libyaml parser failed but there is no error\0"),
             },
-            problem_offset: unsafe { (*parser).problem_offset },
+            problem_offset: unsafe { (&(*parser)).problem_offset },
             problem_mark: Mark {
-                sys: unsafe { (*parser).problem_mark },
+                sys: unsafe { (&(*parser)).problem_mark },
             },
-            context: match NonNull::new(unsafe { (*parser).context as *mut _ }) {
+            context: match NonNull::new(unsafe { (&(*parser)).context as *mut _ }) {
                 Some(context) => Some(unsafe { CStr::from_ptr(context) }),
                 None => None,
             },
             context_mark: Mark {
-                sys: unsafe { (*parser).context_mark },
+                sys: unsafe { (&(*parser)).context_mark },
             },
         }
     }
 
     pub unsafe fn emit_error(emitter: *const sys::yaml_emitter_t) -> Self {
         Error {
-            kind: unsafe { (*emitter).error },
-            problem: match NonNull::new(unsafe { (*emitter).problem as *mut _ }) {
+            kind: unsafe { (&(*emitter)).error },
+            problem: match NonNull::new(unsafe { (&(*emitter)).problem as *mut _ }) {
                 Some(problem) => unsafe { CStr::from_ptr(problem) },
                 None => {
                     CStr::from_bytes_with_nul(b"libyaml emitter failed but there is no error\0")

--- a/dbt-serde_yaml/src/libyaml/parser.rs
+++ b/dbt-serde_yaml/src/libyaml/parser.rs
@@ -84,7 +84,7 @@ impl<'input> Parser<'input> {
         let mut event = MaybeUninit::<sys::yaml_event_t>::uninit();
         unsafe {
             let parser = addr_of_mut!((*self.pin.ptr).sys);
-            if (*parser).error != sys::YAML_NO_ERROR {
+            if (&(*parser)).error != sys::YAML_NO_ERROR {
                 return Err(Error::parse_error(parser));
             }
             let event = event.as_mut_ptr();

--- a/dbt-serde_yaml/src/value/mod.rs
+++ b/dbt-serde_yaml/src/value/mod.rs
@@ -9,6 +9,7 @@ mod ser;
 pub(crate) mod tagged;
 
 use crate::error::{self, Error, ErrorImpl};
+use crate::path::Path;
 use crate::{spanned, Span};
 use serde::de::{Deserialize, DeserializeOwned, IntoDeserializer};
 use serde::Serialize;
@@ -834,7 +835,8 @@ impl Hash for Value {
 impl IntoDeserializer<'_, Error> for Value {
     type Deserializer = de::ValueDeserializer<
         'static,
-        fn(Value, Value),
+        'static,
+        fn(Path<'_>, Value, Value),
         fn(Value) -> Result<Value, Box<dyn std::error::Error + 'static + Send + Sync>>,
     >;
 

--- a/dbt-serde_yaml/src/value/tagged.rs
+++ b/dbt-serde_yaml/src/value/tagged.rs
@@ -1,3 +1,4 @@
+use crate::path::Path;
 use crate::value::de::{MapRefDeserializer, SeqRefDeserializer};
 use crate::value::Value;
 use crate::Error;
@@ -252,7 +253,8 @@ impl<'de> EnumAccess<'de> for TaggedValue {
     type Error = Error;
     type Variant = ValueDeserializer<
         'static,
-        fn(Value, Value),
+        'static,
+        fn(Path<'_>, Value, Value),
         fn(Value) -> Result<Value, Box<dyn std::error::Error + 'static + Send + Sync>>,
     >;
 


### PR DESCRIPTION
This adds Yaml "path" tracking for `duplicate_key_callback` and `unused_key_callback`: the `Path` to the offending key (included) is passed in as the first argument.