### PR TITLE
Implement flatten_dunder and unused_key_callback support for `&Value` deserializer

### DIFF
--- a/dbt-serde_yaml/src/value/de.rs
+++ b/dbt-serde_yaml/src/value/de.rs
@@ -1,5 +1,6 @@
 use crate::mapping::{DuplicateKey, MappingVisitor};
 use crate::path::Path;
+use crate::value::de::borrowed::ValueRefDeserializer;
 use crate::value::tagged::TagStringVisitor;
 use crate::value::TaggedValue;
 use crate::{error, number, spanned, Error, Sequence, Span, Value};
@@ -71,6 +72,16 @@ impl Value {
             Some(&mut field_transformer),
         );
 
+        T::deserialize(de)
+    }
+
+    /// Deserialize a [Value] into an instance of some [Deserialize] type `T`.
+    pub fn to_typed<'de, T, U>(&'de self, mut unused_key_callback: U) -> Result<T, Error>
+    where
+        T: Deserialize<'de>,
+        U: FnMut(Path<'_>, &'de Value, &'de Value),
+    {
+        let de = ValueRefDeserializer::new_with(self, Path::Root, Some(&mut unused_key_callback));
         T::deserialize(de)
     }
 }

--- a/dbt-serde_yaml/src/value/de/owned.rs
+++ b/dbt-serde_yaml/src/value/de/owned.rs
@@ -903,6 +903,7 @@ where
                 ),
                 visitor,
             ),
+            Some(value) => Err(Error::invalid_type(value.unexpected(), &"tuple variant")),
             _ => Err(Error::invalid_type(
                 Unexpected::UnitVariant,
                 &"tuple variant",
@@ -929,6 +930,7 @@ where
                 ),
                 visitor,
             ),
+            Some(value) => Err(Error::invalid_type(value.unexpected(), &"struct variant")),
             _ => Err(Error::invalid_type(
                 Unexpected::UnitVariant,
                 &"struct variant",


### PR DESCRIPTION
* Mirror the `flatten_dunder` and `unused_key_callback` logic to the `*RefDeserializer` code paths
* `Value::to_typed`: new method, a non-consuming version of `Value::into_typed`