### PR TITLE
Add support facilities for untagged enum

### DIFF
--- a/dbt-serde_yaml/src/path.rs
+++ b/dbt-serde_yaml/src/path.rs
@@ -1,6 +1,9 @@
 //! Path to the current value in the input.
 
-use std::fmt::{self, Display};
+use std::{
+    cell::OnceCell,
+    fmt::{self, Display},
+};
 
 /// A structured representation of a path to the current value in the input,
 /// like `dependencies.serde.typo1`.
@@ -53,6 +56,132 @@ impl Display for Path<'_> {
             Path::Map { parent, key } => write!(formatter, "{}{}", Parent(parent), key),
             Path::Alias { parent } => write!(formatter, "{}", parent),
             Path::Unknown { parent } => write!(formatter, "{}?", Parent(parent)),
+        }
+    }
+}
+
+impl<'a> Path<'a> {
+    /// Returns an owned version of this path.
+    pub fn to_owned_path(&self) -> OwnedPath {
+        match self {
+            Path::Root => OwnedPath::Root,
+            Path::Seq { parent, index } => OwnedPath::Seq {
+                parent: Box::new(parent.to_owned_path()),
+                index: *index,
+                borrowed: OnceCell::new(),
+            },
+            Path::Map { parent, key } => OwnedPath::Map {
+                parent: Box::new(parent.to_owned_path()),
+                key: key.to_string(),
+                borrowed: OnceCell::new(),
+            },
+            Path::Alias { parent } => OwnedPath::Alias {
+                parent: Box::new(parent.to_owned_path()),
+                borrowed: OnceCell::new(),
+            },
+            Path::Unknown { parent } => OwnedPath::Unknown {
+                parent: Box::new(parent.to_owned_path()),
+                borrowed: OnceCell::new(),
+            },
+        }
+    }
+}
+
+/// An owned version of a [Path].
+pub enum OwnedPath {
+    /// The root of the input.
+    Root,
+    /// A sequence index.
+    Seq {
+        /// The path to the parent value.
+        parent: Box<OwnedPath>,
+        /// The index of the current value.
+        index: usize,
+        /// A cell to hold the borrowed path.
+        borrowed: OnceCell<Path<'static>>,
+    },
+    /// A map key.
+    Map {
+        /// The path to the parent value.
+        parent: Box<OwnedPath>,
+        /// The key of the current value.
+        key: String,
+        /// A cell to hold the borrowed path.
+        borrowed: OnceCell<Path<'static>>,
+    },
+    /// An alias.
+    Alias {
+        /// The path to the parent value.
+        parent: Box<OwnedPath>,
+        /// A cell to hold the borrowed path.
+        borrowed: OnceCell<Path<'static>>,
+    },
+    /// An unknown path.
+    Unknown {
+        /// The path to the parent value.
+        parent: Box<OwnedPath>,
+        /// A cell to hold the borrowed path.
+        borrowed: OnceCell<Path<'static>>,
+    },
+}
+
+impl<'a> OwnedPath {
+    /// Returns a borrowed version of this path.
+    pub fn as_path(&'a self) -> &'a Path<'a> {
+        static ROOT: Path<'static> = Path::Root;
+
+        match self {
+            OwnedPath::Root => &ROOT,
+            OwnedPath::Seq {
+                parent,
+                index,
+                borrowed,
+            } => {
+                let borrowed = borrowed.get_or_init(|| {
+                    let parent = parent.as_path();
+                    // SAFETY: self-reference
+                    unsafe {
+                        std::mem::transmute(Path::Seq {
+                            parent,
+                            index: *index,
+                        })
+                    }
+                });
+                borrowed
+            }
+            OwnedPath::Map {
+                parent,
+                key,
+                borrowed,
+            } => {
+                let borrowed = borrowed.get_or_init(|| {
+                    let parent = parent.as_path();
+                    // SAFETY: self-reference
+                    unsafe {
+                        std::mem::transmute(Path::Map {
+                            parent,
+                            key: key.as_ref(),
+                        })
+                    }
+                });
+                borrowed
+            }
+            OwnedPath::Alias { parent, borrowed } => {
+                let borrowed = borrowed.get_or_init(|| {
+                    let parent = parent.as_path();
+                    // SAFETY: self-reference
+                    unsafe { std::mem::transmute(Path::Alias { parent }) }
+                });
+                borrowed
+            }
+            OwnedPath::Unknown { parent, borrowed } => {
+                let borrowed = borrowed.get_or_init(|| {
+                    let parent = parent.as_path();
+                    // SAFETY: self-reference
+                    unsafe { std::mem::transmute(Path::Unknown { parent }) }
+                });
+                borrowed
+            }
         }
     }
 }

--- a/dbt-serde_yaml/src/value/de.rs
+++ b/dbt-serde_yaml/src/value/de.rs
@@ -446,14 +446,16 @@ where
 pub type UnusedKeyCallback = Box<dyn for<'p, 'v> FnMut(Path<'p>, &'v Value, &'v Value)>;
 pub type FieldTransformer = Box<dyn for<'v> FnMut(&'v Value) -> TransformedResult>;
 
+/// Captures the state of a [Value] deserializer
 pub struct DeserializerState {
     value: Value,
     path: OwnedPath,
-    pub unused_key_callback: Option<UnusedKeyCallback>,
+    unused_key_callback: Option<UnusedKeyCallback>,
     field_transformer: Option<FieldTransformer>,
 }
 
 impl DeserializerState {
+    /// Constructs a Value [Deserializer] from the captured state
     pub fn get_deserializer<'de, 'u, U>(
         &'de mut self,
         unused_key_callback: Option<&'u mut U>,
@@ -470,6 +472,11 @@ impl DeserializerState {
             unused_key_callback,
             field_transformer,
         )
+    }
+
+    /// Extracts the unused key callback from the state, if any. 
+    pub fn take_unused_key_callback(&mut self) -> Option<UnusedKeyCallback> {
+        self.unused_key_callback.take()
     }
 }
 

--- a/dbt-serde_yaml/src/value/de/borrowed.rs
+++ b/dbt-serde_yaml/src/value/de/borrowed.rs
@@ -13,7 +13,7 @@ use crate::{
     value::{
         de::{
             is_deserializing_value_then_reset, reset_is_deserializing_value,
-            store_deserializer_state, ValueDeserializer,
+            save_deserializer_state, ValueDeserializer,
         },
         tagged,
     },
@@ -445,7 +445,7 @@ where
         let span = self.value.span();
         self.value.broadcast_end_mark();
         if is_deserializing_value_then_reset() {
-            store_deserializer_state(
+            save_deserializer_state(
                 Some(self.value.clone()),
                 self.path,
                 self.unused_key_callback,

--- a/dbt-serde_yaml/src/value/de/owned.rs
+++ b/dbt-serde_yaml/src/value/de/owned.rs
@@ -13,7 +13,7 @@ use crate::{
     value::{
         de::{
             borrowed::ValueRefDeserializer, is_deserializing_value_then_reset,
-            reset_is_deserializing_value, store_deserializer_state,
+            reset_is_deserializing_value, save_deserializer_state,
         },
         tagged,
     },
@@ -452,7 +452,7 @@ where
         let span = self.value.span();
         self.value.broadcast_end_mark();
         if is_deserializing_value_then_reset() {
-            store_deserializer_state(
+            save_deserializer_state(
                 Some(self.value),
                 self.path,
                 self.unused_key_callback,

--- a/dbt-serde_yaml/src/value/mod.rs
+++ b/dbt-serde_yaml/src/value/mod.rs
@@ -26,6 +26,7 @@ pub use crate::number::Number;
 pub(crate) use de::ValueVisitor;
 
 pub use de::extract_reusable_deserializer_state;
+pub use de::DeserializerState;
 pub use de::TransformedResult;
 
 /// Represents any valid YAML value.

--- a/dbt-serde_yaml/src/value/mod.rs
+++ b/dbt-serde_yaml/src/value/mod.rs
@@ -25,6 +25,7 @@ pub use crate::number::Number;
 #[doc(inline)]
 pub(crate) use de::ValueVisitor;
 
+pub use de::extract_reusable_deserializer_state;
 pub use de::TransformedResult;
 
 /// Represents any valid YAML value.

--- a/dbt-serde_yaml/src/verbatim.rs
+++ b/dbt-serde_yaml/src/verbatim.rs
@@ -160,7 +160,6 @@ impl<'de> Deserializer<'de> for MissingFieldDeserializer {
         visitor.visit_none()
     }
 
-    // Other methods are not needed for this deserializer.
     serde::forward_to_deserialize_any! {
         bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64 char str string bytes byte_buf
         unit unit_struct newtype_struct seq tuple tuple_struct map struct
@@ -184,7 +183,7 @@ where
             Ok(value) => Ok(Verbatim::new(value)),
             Err(err) => {
                 let msg = err.to_string();
-                // missing field errors must be handled specially, as dictated by T:
+                // missing field errors must be handled as dictated by T:
                 if msg.starts_with("missing field ")
                     && T::deserialize(MissingFieldDeserializer).is_ok()
                 {
@@ -192,7 +191,7 @@ where
                     // retain the missing field in the Verbatim value:
                     Ok(Verbatim::new_missing())
                 } else {
-                    // Otherwise, we propagate the error.
+                    // Otherwise, we propagate the error:
                     Err(err)
                 }
             }
@@ -233,6 +232,8 @@ where
         T::_schemars_private_is_option()
     }
 }
+
+////////////////////////////////////////////////////////////////////////
 
 /// A wrapper type that protects the inner value from being transformed by the
 /// `field_transformer` when deserialized by the `Value::into_typed` method.

--- a/dbt-serde_yaml/tests/test_value.rs
+++ b/dbt-serde_yaml/tests/test_value.rs
@@ -916,6 +916,7 @@ fn test_untagged_enum() {
         c: bool,
     }
 
+    #[allow(clippy::large_enum_variant)]
     #[derive(PartialEq, Eq, Debug)]
     // #[serde(untagged)]
     enum Untagged {
@@ -930,7 +931,7 @@ fn test_untagged_enum() {
             D: serde::Deserializer<'de>,
         {
             let mut state = extract_reusable_deserializer_state(deserializer)?;
-            let unused_key_callback = state.unused_key_callback.take();
+            let unused_key_callback = state.take_unused_key_callback();
             let mut unused_keys = vec![];
 
             let string = {
@@ -943,7 +944,7 @@ fn test_untagged_enum() {
             if let Ok(s) = string {
                 if let Some(mut callback) = unused_key_callback {
                     for (path, key, value) in unused_keys.iter() {
-                        callback(path.as_path().clone(), &key, &value);
+                        callback(*path.as_path(), key, value);
                     }
                 }
                 return Ok(Untagged::String(s));
@@ -959,12 +960,11 @@ fn test_untagged_enum() {
             if let Ok(n) = number {
                 if let Some(mut callback) = unused_key_callback {
                     for (path, key, value) in unused_keys.iter() {
-                        callback(path.as_path().clone(), &key, &value);
+                        callback(*path.as_path(), key, value);
                     }
                 }
                 return Ok(Untagged::Number(n));
             }
-            drop(number);
 
             unused_keys.clear();
             let thing = {
@@ -976,7 +976,7 @@ fn test_untagged_enum() {
             if let Ok(t) = thing {
                 if let Some(mut callback) = unused_key_callback {
                     for (path, key, value) in unused_keys.iter() {
-                        callback(path.as_path().clone(), &key, &value);
+                        callback(*path.as_path(), key, value);
                     }
                 }
                 return Ok(Untagged::Thing(t));

--- a/dbt-serde_yaml/tests/test_value.rs
+++ b/dbt-serde_yaml/tests/test_value.rs
@@ -6,8 +6,9 @@
 
 use std::collections::HashMap;
 
-use dbt_serde_yaml::Mapping;
+use dbt_serde_yaml::value::extract_reusable_deserializer_state;
 use dbt_serde_yaml::{value::TransformedResult, Number, Value, Verbatim};
+use dbt_serde_yaml::{Mapping, Path};
 use indoc::indoc;
 use serde::de::{DeserializeOwned, IntoDeserializer};
 use serde::Deserialize as _;
@@ -903,5 +904,127 @@ properties:
     type: integer
     format: int32
 "}
+    );
+}
+
+#[test]
+fn test_untagged_enum() {
+    #[derive(Deserialize, PartialEq, Eq, Debug)]
+    struct Thing {
+        a: Verbatim<i32>,
+        b: Verbatim<Option<i32>>,
+        c: bool,
+    }
+
+    #[derive(PartialEq, Eq, Debug)]
+    // #[serde(untagged)]
+    enum Untagged {
+        String(String),
+        Number(i32),
+        Thing(Thing),
+    }
+
+    impl<'de> serde::Deserialize<'de> for Untagged {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            let mut state = extract_reusable_deserializer_state(deserializer)?;
+            let unused_key_callback = state.unused_key_callback.take();
+            let mut unused_keys = vec![];
+
+            let string = {
+                let mut collect_unused_keys = |path: Path<'_>, key: &Value, value: &Value| {
+                    unused_keys.push((path.to_owned_path(), key.clone(), value.clone()));
+                };
+
+                String::deserialize(state.get_deserializer(Some(&mut collect_unused_keys)))
+            };
+            if let Ok(s) = string {
+                if let Some(mut callback) = unused_key_callback {
+                    for (path, key, value) in unused_keys.iter() {
+                        callback(path.as_path().clone(), &key, &value);
+                    }
+                }
+                return Ok(Untagged::String(s));
+            }
+
+            unused_keys.clear();
+            let number = {
+                let mut collect_unused_keys = |path: Path<'_>, key: &Value, value: &Value| {
+                    unused_keys.push((path.to_owned_path(), key.clone(), value.clone()));
+                };
+                i32::deserialize(state.get_deserializer(Some(&mut collect_unused_keys)))
+            };
+            if let Ok(n) = number {
+                if let Some(mut callback) = unused_key_callback {
+                    for (path, key, value) in unused_keys.iter() {
+                        callback(path.as_path().clone(), &key, &value);
+                    }
+                }
+                return Ok(Untagged::Number(n));
+            }
+            drop(number);
+
+            unused_keys.clear();
+            let thing = {
+                let mut collect_unused_keys = |path: Path<'_>, key: &Value, value: &Value| {
+                    unused_keys.push((path.to_owned_path(), key.clone(), value.clone()));
+                };
+                Thing::deserialize(state.get_deserializer(Some(&mut collect_unused_keys)))
+            };
+            if let Ok(t) = thing {
+                if let Some(mut callback) = unused_key_callback {
+                    for (path, key, value) in unused_keys.iter() {
+                        callback(path.as_path().clone(), &key, &value);
+                    }
+                }
+                return Ok(Untagged::Thing(t));
+            }
+
+            Err(serde::de::Error::custom(
+                "Failed to deserialize Untagged enum",
+            ))
+        }
+    }
+
+    let value = dbt_serde_yaml::from_str::<Value>("42").unwrap();
+    let untagged = deserialize_value::<Untagged>(value, |_| Ok(None)).0;
+    assert_eq!(untagged, Untagged::Number(42));
+
+    let value = dbt_serde_yaml::from_str::<Value>("'hello'").unwrap();
+    let untagged = deserialize_value::<Untagged>(value, |_| Ok(None)).0;
+    assert_eq!(untagged, Untagged::String("hello".to_string()));
+
+    let yaml = indoc! {"
+        a: 3
+        y: '5'
+        c: false
+    "};
+    let value = dbt_serde_yaml::from_str::<Value>(yaml).unwrap();
+    let (untagged, unused_keys) = deserialize_value::<Untagged>(value, |v| {
+        if v.is_u64() {
+            Ok(Some(Value::from(v.as_u64().unwrap() + 100)))
+        } else if v.is_bool() {
+            Ok(Some(Value::from(true)))
+        } else {
+            Ok(None)
+        }
+    });
+    assert_eq!(
+        unused_keys,
+        vec![(
+            "y".to_string(),
+            Value::string("y".to_string()),
+            Value::string("5".to_string())
+        )]
+    );
+    assert_eq!(
+        untagged,
+        Untagged::Thing(Thing {
+            a: Verbatim::new(Value::from(3)),
+            b: Verbatim::new_missing(),
+            c: true,
+        })
     );
 }


### PR DESCRIPTION
`Value::de`: add mechanisms for save/load of `Deserializer` state to support backtracking on deserializing untagged enums.