### PR TITLE
Fix infinite type generated by UntaggedEnumDeserialize

### DIFF
--- a/dbt-serde_yaml/src/value/de.rs
+++ b/dbt-serde_yaml/src/value/de.rs
@@ -433,7 +433,10 @@ where
     }
 }
 
+/// A callback type for handling unused keys during deserialization.
 pub type UnusedKeyCallback<'u> = Box<dyn for<'p, 'v> FnMut(Path<'p>, &'v Value, &'v Value) + 'u>;
+
+/// A transformer function for modifying field values during deserialization.
 pub type FieldTransformer<'f> = Box<dyn for<'v> FnMut(&'v Value) -> TransformedResult + 'f>;
 
 /// Captures the state of a [Value] deserializer
@@ -467,7 +470,7 @@ impl DeserializerState {
     ) -> ValueRefDeserializer<'de, 'u, 'de, U, FieldTransformer<'static>>
     where
         'de: 'u,
-        U: FnMut(Path<'_>, &Value, &Value),
+        U: for<'v> FnMut(Path<'_>, &'v Value, &'v Value),
     {
         let field_transformer = self.field_transformer.as_mut();
 

--- a/dbt-serde_yaml/src/value/mod.rs
+++ b/dbt-serde_yaml/src/value/mod.rs
@@ -27,7 +27,9 @@ pub(crate) use de::ValueVisitor;
 
 pub use de::extract_reusable_deserializer_state;
 pub use de::DeserializerState;
+pub use de::FieldTransformer;
 pub use de::TransformedResult;
+pub use de::UnusedKeyCallback;
 
 /// Represents any valid YAML value.
 #[derive(Clone)]

--- a/dbt-serde_yaml_derive/src/lib.rs
+++ b/dbt-serde_yaml_derive/src/lib.rs
@@ -89,9 +89,9 @@ impl<'a> Variant<'a> {
         let block = quote! {
             __unused_keys.clear();
             let __inner = {
-                let mut collect_unused_keys = |path: __serde_yaml::Path<'_>, key: &__serde_yaml::Value, value: &__serde_yaml::Value| {
+                let mut collect_unused_keys: __serde_yaml::value::UnusedKeyCallback  = Box::new(|path: __serde_yaml::Path<'_>, key: &__serde_yaml::Value, value: &__serde_yaml::Value| {
                     __unused_keys.push((path.to_owned_path(), key.clone(), value.clone()));
-                };
+                });
 
                 #type_name::deserialize(__state.get_deserializer(Some(&mut collect_unused_keys)))
             };


### PR DESCRIPTION
Type-erase the `unused_key_callback` generated by `UntaggedEnumDeserialize` to avoid generating infinite types on untagged enums with recursive types.