### PR TITLE
Value: fix deserialize_any short circuit condition

### DIFF
--- a/dbt-serde_yaml/src/value/de/borrowed.rs
+++ b/dbt-serde_yaml/src/value/de/borrowed.rs
@@ -11,10 +11,7 @@ use serde::{
 use crate::{
     error,
     value::{
-        de::{
-            is_deserializing_value_then_reset, reset_is_deserializing_value,
-            save_deserializer_state, ValueDeserializer,
-        },
+        de::{reset_is_deserializing_value, save_deserializer_state, ValueDeserializer},
         tagged,
     },
     Error, Mapping, Path, Sequence, Value,
@@ -442,7 +439,7 @@ where
     {
         let span = self.value.span();
         self.value.broadcast_end_mark();
-        if is_deserializing_value_then_reset() {
+        if super::should_short_circuit_any(self.field_transformer.is_some()) {
             // SAFETY: self.unused_key_callback and self.field_transformer are
             // passed in from outside and guaranteed to be valid for 'de
             unsafe {
@@ -1376,7 +1373,7 @@ where
     where
         V: Visitor<'de>,
     {
-        if is_deserializing_value_then_reset() {
+        if super::should_short_circuit_any(self.field_transformer.is_some()) {
             let value = Value::mapping(
                 self.iter
                     .into_iter()
@@ -1684,7 +1681,7 @@ where
             self.remaining.push((key, value));
         };
 
-        if is_deserializing_value_then_reset() {
+        if super::should_short_circuit_any(self.field_transformer.is_some()) {
             let value = Value::mapping(
                 self.iter
                     .into_iter()

--- a/dbt-serde_yaml/src/value/de/owned.rs
+++ b/dbt-serde_yaml/src/value/de/owned.rs
@@ -12,8 +12,7 @@ use crate::{
     error,
     value::{
         de::{
-            borrowed::ValueRefDeserializer, is_deserializing_value_then_reset,
-            reset_is_deserializing_value, save_deserializer_state,
+            borrowed::ValueRefDeserializer, reset_is_deserializing_value, save_deserializer_state,
         },
         tagged,
     },
@@ -448,7 +447,7 @@ where
     {
         let span = self.value.span();
         self.value.broadcast_end_mark();
-        if is_deserializing_value_then_reset() {
+        if super::should_short_circuit_any(self.field_transformer.is_some()) {
             // SAFETY: self.unused_key_callback and self.field_transformer are
             // passed in from outside and guaranteed to be valid for 'de
             unsafe {
@@ -1299,7 +1298,7 @@ where
     where
         V: Visitor<'de>,
     {
-        if is_deserializing_value_then_reset() {
+        if super::should_short_circuit_any(self.field_transformer.is_some()) {
             let value = Value::mapping(self.iter.collect());
             // SAFETY: self.unused_key_callback and self.field_transformer are
             // passed in from outside and guaranteed to be valid for 'de
@@ -1568,7 +1567,7 @@ where
             self.remaining.push((key.clone(), value.clone()));
         };
 
-        if is_deserializing_value_then_reset() {
+        if super::should_short_circuit_any(self.field_transformer.is_some()) {
             let value = Value::mapping(self.iter.collect());
             // SAFETY: self.unused_key_callback and self.field_transformer are
             // passed in from outside and guaranteed to be valid for 'de

--- a/dbt-serde_yaml/src/verbatim.rs
+++ b/dbt-serde_yaml/src/verbatim.rs
@@ -187,7 +187,7 @@ pub(crate) fn should_transform_any() -> bool {
     SHOULD_TRANSFORM_ANY.with(|flag| flag.get())
 }
 
-struct ShouldTransformAnyGuard(bool);
+pub(crate) struct ShouldTransformAnyGuard(bool);
 
 impl Drop for ShouldTransformAnyGuard {
     fn drop(&mut self) {
@@ -195,7 +195,7 @@ impl Drop for ShouldTransformAnyGuard {
     }
 }
 
-fn with_should_not_transform_any() -> ShouldTransformAnyGuard {
+pub(crate) fn with_should_not_transform_any() -> ShouldTransformAnyGuard {
     let current = SHOULD_TRANSFORM_ANY.with(|flag| flag.get());
     SHOULD_TRANSFORM_ANY.with(|flag| flag.set(false));
     ShouldTransformAnyGuard(current)

--- a/dbt-serde_yaml/tests/test_value.rs
+++ b/dbt-serde_yaml/tests/test_value.rs
@@ -191,7 +191,7 @@ fn test_into_typed() {
             first: Value::string("abc".to_string()).into(),
             third: 100,
             // Non-verbatim fields should be transformed:
-            fourth: Value::string("my name".to_string()).into(),
+            fourth: Value::string("my name".to_string()),
         }
     );
 
@@ -279,7 +279,7 @@ fn test_into_typed() {
         Test2 {
             first: Value::string("A".to_string()).into(),
             third: 3,
-            fourth: Value::string("D".to_string()).into(),
+            fourth: Value::string("D".to_string()),
         }
     );
 }

--- a/dbt-serde_yaml/tests/test_value.rs
+++ b/dbt-serde_yaml/tests/test_value.rs
@@ -140,23 +140,32 @@ fn test_into_typed() {
     struct Test2 {
         first: Verbatim<Value>,
         third: u32,
+        fourth: Value,
     }
 
     let value = dbt_serde_yaml::from_str::<Value>(indoc! {"
         first: abc
         second: 99
         third: 100
+        fourth: my
         "})
     .unwrap();
 
     let (test, unused_keys): (Test, _) = deserialize_value(value.clone(), transformer);
     assert_eq!(
         unused_keys,
-        vec![(
-            "third".to_string(),
-            Value::string("third".to_string()),
-            Value::number(Number::from(100))
-        )]
+        vec![
+            (
+                "third".to_string(),
+                Value::string("third".to_string()),
+                Value::number(Number::from(100))
+            ),
+            (
+                "fourth".to_string(),
+                Value::string("fourth".to_string()),
+                Value::string("my".to_string())
+            )
+        ]
     );
     assert_eq!(
         test,
@@ -180,7 +189,9 @@ fn test_into_typed() {
         Test2 {
             // field_transform is not applied to `Verbatim`-typed fields:
             first: Value::string("abc".to_string()).into(),
-            third: 100
+            third: 100,
+            // Non-verbatim fields should be transformed:
+            fourth: Value::string("my name".to_string()).into(),
         }
     );
 
@@ -203,8 +214,10 @@ fn test_into_typed() {
           -   first: A
               second: 1
               third: 1
+              fourth: D
           -   first: B
               third: 2
+              fourth: X
         fourth: xyz
         third: xyz
         fifth:
@@ -265,7 +278,8 @@ fn test_into_typed() {
         test2_1,
         Test2 {
             first: Value::string("A".to_string()).into(),
-            third: 3
+            third: 3,
+            fourth: Value::string("D".to_string()).into(),
         }
     );
 }


### PR DESCRIPTION
We should not short-circuit to Value when we have `field_transformer` present.