### PR TITLE
Type-erase callbacks

### DIFF
--- a/dbt-serde_yaml/examples/enum.rs
+++ b/dbt-serde_yaml/examples/enum.rs
@@ -1,0 +1,64 @@
+use dbt_serde_yaml::from_str;
+use dbt_serde_yaml::UntaggedEnumDeserialize;
+use serde_derive::Deserialize;
+use serde_derive::Serialize;
+
+struct BThing<'f> {
+    callback: Option<&'f mut dyn FnMut(&str) -> String>,
+}
+
+impl<'f> BThing<'f> {
+    fn new(callback: Option<&'f mut dyn FnMut(&str) -> String>) -> Self {
+        BThing { callback }
+    }
+
+    fn call(&mut self, input: &str) -> String {
+        if let Some(callback) = self.callback.as_mut() {
+            callback(input)
+        } else {
+            String::from("No callback set")
+        }
+    }
+}
+
+pub fn main() {
+    #[derive(Debug, Serialize, Deserialize)]
+    struct AThing {
+        key1: String,
+        key2: i32,
+        key3: Inner,
+    }
+
+    #[derive(Debug, Serialize, UntaggedEnumDeserialize)]
+    #[serde(untagged)]
+    enum Inner {
+        V(Vec<String>),
+        I(i32),
+        T(Vec<Thing>),
+    }
+
+    #[derive(Debug, Serialize, UntaggedEnumDeserialize)]
+    #[serde(untagged)]
+    enum Thing {
+        A(AThing),
+        B,
+    }
+    use dbt_serde_yaml::Value;
+    let yaml_data = r#"
+        key1: value1
+        key2: 42
+        key3:
+          - item1
+          - item2
+    "#;
+    let value: Value = from_str(yaml_data).expect("Failed to deserialize YAML");
+    let thing: Thing = value.into_typed(|_, _, _| {}, |_| Ok(None)).unwrap();
+
+    println!("{0:?}\n", thing);
+
+    let mut callback = |input: &str| -> String { format!("Callback called with input: {}", input) };
+    let mut b_thing = BThing::new(Some(&mut callback));
+
+    let result = b_thing.call("test input");
+    println!("BThing call result: {}", result);
+}

--- a/dbt-serde_yaml/src/mapping.rs
+++ b/dbt-serde_yaml/src/mapping.rs
@@ -1,7 +1,7 @@
 //! A YAML mapping and its iterator types.
 
 use crate::path::Path;
-use crate::value::ValueVisitor;
+use crate::value::{DuplicateKeyCallback, ValueVisitor};
 use crate::{private, Value};
 use indexmap::IndexMap;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -826,15 +826,12 @@ pub enum DuplicateKey {
     Overwrite,
 }
 
-pub(crate) struct MappingVisitor<'a, 'b, F: FnMut(Path<'_>, &Value, &Value) -> DuplicateKey> {
-    pub callback: &'a mut F,
+pub(crate) struct MappingVisitor<'d, 'b> {
+    pub callback: DuplicateKeyCallback<'d>,
     pub path: Path<'b>,
 }
 
-impl<'de, F> serde::de::Visitor<'de> for MappingVisitor<'_, '_, F>
-where
-    F: FnMut(Path<'_>, &Value, &Value) -> DuplicateKey,
-{
+impl<'de> serde::de::Visitor<'de> for MappingVisitor<'_, '_> {
     type Value = Mapping;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/dbt-serde_yaml/src/value/mod.rs
+++ b/dbt-serde_yaml/src/value/mod.rs
@@ -9,7 +9,6 @@ mod ser;
 pub(crate) mod tagged;
 
 use crate::error::{self, Error, ErrorImpl};
-use crate::path::Path;
 use crate::{spanned, Span};
 use serde::de::{Deserialize, DeserializeOwned, IntoDeserializer};
 use serde::Serialize;
@@ -28,6 +27,7 @@ pub(crate) use de::ValueVisitor;
 pub use de::extract_reusable_deserializer_state;
 pub use de::extract_tag_and_deserializer_state;
 pub use de::DeserializerState;
+pub use de::DuplicateKeyCallback;
 pub use de::FieldTransformer;
 pub use de::TransformedResult;
 pub use de::UnusedKeyCallback;
@@ -840,12 +840,7 @@ impl Hash for Value {
 }
 
 impl IntoDeserializer<'_, Error> for Value {
-    type Deserializer = de::ValueDeserializer<
-        'static,
-        'static,
-        fn(Path<'_>, &Value, &Value),
-        fn(&Value) -> de::TransformedResult,
-    >;
+    type Deserializer = de::ValueDeserializer<'static, 'static, 'static>;
 
     fn into_deserializer(self) -> Self::Deserializer {
         de::ValueDeserializer::new(self)

--- a/dbt-serde_yaml/src/value/tagged.rs
+++ b/dbt-serde_yaml/src/value/tagged.rs
@@ -1,4 +1,3 @@
-use crate::path::Path;
 use crate::value::de::{MapRefDeserializer, SeqRefDeserializer};
 use crate::value::Value;
 use crate::Error;
@@ -251,12 +250,7 @@ impl<'de> Deserializer<'de> for TaggedValue {
 
 impl<'de> EnumAccess<'de> for TaggedValue {
     type Error = Error;
-    type Variant = ValueDeserializer<
-        'static,
-        'static,
-        fn(Path<'_>, &Value, &Value),
-        fn(&Value) -> super::de::TransformedResult,
-    >;
+    type Variant = ValueDeserializer<'static, 'static, 'static>;
 
     fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Error>
     where

--- a/dbt-serde_yaml_derive/src/lib.rs
+++ b/dbt-serde_yaml_derive/src/lib.rs
@@ -168,10 +168,10 @@ impl<'a> Variant<'a> {
         let block = quote! {
             __unused_keys.clear();
             let __inner = {
-                let mut collect_unused_keys: __serde_yaml::value::UnusedKeyCallback  =
-                    Box::new(|path: __serde_yaml::Path<'_>, key: &__serde_yaml::Value, value: &__serde_yaml::Value| {
+                let mut collect_unused_keys =
+                    |path: __serde_yaml::Path<'_>, key: &__serde_yaml::Value, value: &__serde_yaml::Value| {
                         __unused_keys.push((path.to_owned_path(), key.clone(), value.clone()));
-                    });
+                    };
 
                 #type_name::deserialize(__state.get_deserializer(Some(&mut collect_unused_keys)))
             };


### PR DESCRIPTION
Type-erase all closure types from internal `Deserializer`/`Visitor` structs to avoid super-linear code size blow up on monomorphization.