### PR TITLE
Mapping: fix key location

### DIFF
--- a/dbt-serde_yaml/src/spanned/mod.rs
+++ b/dbt-serde_yaml/src/spanned/mod.rs
@@ -101,7 +101,8 @@ where
     T: Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?} {:?}", self.span, self.node)
+        write!(f, "{{{:?}}} ", self.span)?;
+        Debug::fmt(&self.node, f)
     }
 }
 

--- a/dbt-serde_yaml/src/value/de/borrowed.rs
+++ b/dbt-serde_yaml/src/value/de/borrowed.rs
@@ -1277,7 +1277,8 @@ impl<'de> MapAccess<'de> for MapRefDeserializer<'de, '_, '_, '_> {
             Some((key, value)) => {
                 self.value = Some(value);
                 self.current_key = key.as_str().map(String::from);
-                seed.deserialize(key).map(Some)
+                let deserializer = ValueRefDeserializer::new_with(key, self.path, None, None);
+                seed.deserialize(deserializer).map(Some)
             }
             None => Ok(None),
         }

--- a/dbt-serde_yaml/src/value/de/owned.rs
+++ b/dbt-serde_yaml/src/value/de/owned.rs
@@ -1209,7 +1209,8 @@ impl<'de, 'u, 'f> MapAccess<'de> for MapDeserializer<'_, 'u, 'f> {
             Some((key, value)) => {
                 self.value = Some(value);
                 self.current_key = key.as_str().map(|s| s.to_string());
-                seed.deserialize(key).map(Some)
+                let deserializer = ValueDeserializer::new_with(key, self.path, None, None);
+                seed.deserialize(deserializer).map(Some)
             }
             None => Ok(None),
         }

--- a/dbt-serde_yaml/src/value/debug.rs
+++ b/dbt-serde_yaml/src/value/debug.rs
@@ -1,6 +1,6 @@
 use crate::mapping::Mapping;
 use crate::value::{Number, Value};
-use std::fmt::{self, Debug, Display};
+use std::fmt::{self, Debug};
 
 impl Debug for Value {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -16,15 +16,8 @@ impl Debug for Value {
             }
             Value::Mapping(mapping, ..) => Debug::fmt(mapping, formatter),
             Value::Tagged(tagged, ..) => Debug::fmt(tagged, formatter),
-        }
-    }
-}
-
-struct DisplayNumber<'a>(&'a Number);
-
-impl Debug for DisplayNumber<'_> {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        Display::fmt(self.0, formatter)
+        }?;
+        write!(formatter, " @{{{:?}}}", self.span())
     }
 }
 
@@ -39,19 +32,7 @@ impl Debug for Mapping {
         formatter.write_str("Mapping ")?;
         let mut debug = formatter.debug_map();
         for (k, v) in self {
-            let tmp;
-            debug.entry(
-                match k {
-                    Value::Bool(boolean, ..) => boolean,
-                    Value::Number(number, ..) => {
-                        tmp = DisplayNumber(number);
-                        &tmp
-                    }
-                    Value::String(string, ..) => string,
-                    _ => k,
-                },
-                v,
-            );
+            debug.entry(k, v);
         }
         debug.finish()
     }

--- a/dbt-serde_yaml/tests/test_value.rs
+++ b/dbt-serde_yaml/tests/test_value.rs
@@ -383,23 +383,24 @@ fn test_debug() {
     let value: Value = dbt_serde_yaml::from_str(yaml).unwrap();
     assert!(value.span().is_valid());
     let debug = format!("{:#?}", value);
+    eprintln!("{debug}");
 
     let expected = indoc! {r#"
-        Mapping {
-            "Null": Null,
-            "Bool": Bool(true),
-            "Number": Number(1),
-            "String": String("..."),
-            "Sequence": Sequence [
-                Bool(true),
-            ],
-            "EmptySequence": Sequence [],
-            "EmptyMapping": Mapping {},
-            "Tagged": TaggedValue {
-                tag: !tag,
-                value: Bool(true),
-            },
-        }"#
+Mapping {
+    String("Null") @{1:1[0]..1:9[8]}: Null @{1:9[8]..2:1[10]},
+    String("Bool") @{2:1[10]..2:7[16]}: Bool(true) @{2:7[16]..3:1[21]},
+    String("Number") @{3:1[21]..3:9[29]}: Number(1) @{3:9[29]..4:1[31]},
+    String("String") @{4:1[31]..4:9[39]}: String("...") @{4:9[39]..5:1[43]},
+    String("Sequence") @{5:1[43]..6:3[55]}: Sequence [
+        Bool(true) @{6:5[57]..7:1[62]},
+    ] @{6:3[55]..7:1[62]},
+    String("EmptySequence") @{7:1[62]..7:16[77]}: Sequence [] @{7:16[77]..8:1[80]},
+    String("EmptyMapping") @{8:1[80]..8:15[94]}: Mapping {} @{8:15[94]..9:1[97]},
+    String("Tagged") @{9:1[97]..9:9[105]}: TaggedValue {
+        tag: !tag,
+        value: Bool(true) @{10:1[115]..10:1[115]},
+    } @{9:9[105]..10:1[115]},
+} @{1:1[0]..10:1[115]}"#
     };
 
     assert_eq!(debug, expected);


### PR DESCRIPTION
* Fix incorrect source `span` captured by the first key when deserializing from a `Value::Mapping` to a `Value::Mapping`
* Add span info to debug repr of `Value` objects