### PR TITLE
Throw an error if duplicate anchors are detected

### DIFF
--- a/dbt-serde_yaml/src/error.rs
+++ b/dbt-serde_yaml/src/error.rs
@@ -29,6 +29,10 @@ pub(crate) enum ErrorImpl {
     RepetitionLimitExceeded,
     BytesUnsupported,
     UnknownAnchor(Marker),
+    DuplicateAnchor {
+        first: Marker,
+        second: Marker,
+    },
     SerializeNestedEnum,
     ScalarInMerge,
     TaggedInMerge,
@@ -86,6 +90,11 @@ impl Error {
         } else {
             None
         }
+    }
+
+    /// Returns `true` if this error is caused by a duplicate YAML anchor name.
+    pub fn is_duplicate_anchor(&self) -> bool {
+        self.0.is_duplicate_anchor()
     }
 
     /// Returns the error message without the location information.
@@ -207,6 +216,14 @@ impl de::Error for Error {
 }
 
 impl ErrorImpl {
+    fn is_duplicate_anchor(&self) -> bool {
+        match self {
+            ErrorImpl::DuplicateAnchor { .. } => true,
+            ErrorImpl::Shared(inner) => inner.is_duplicate_anchor(),
+            _ => false,
+        }
+    }
+
     fn location(&self) -> Option<Marker> {
         self.span().map(|span| span.start)
     }
@@ -227,6 +244,7 @@ impl ErrorImpl {
             ErrorImpl::RecursionLimitExceeded(mark) | ErrorImpl::UnknownAnchor(mark) => {
                 Some(Span::from(*mark))
             }
+            ErrorImpl::DuplicateAnchor { second, .. } => Some(Span::from(*second)),
             ErrorImpl::Libyaml(err) => Some(Marker::from(err.mark()).into()),
             ErrorImpl::Shared(err) => err.span(),
             _ => None,
@@ -255,6 +273,12 @@ impl ErrorImpl {
                 f.write_str("serialization and deserialization of bytes in YAML is not implemented")
             }
             ErrorImpl::UnknownAnchor(_mark) => f.write_str("unknown anchor"),
+            ErrorImpl::DuplicateAnchor { first, .. } => write!(
+                f,
+                "found duplicate anchor; first occurrence at line {} column {}",
+                first.line(),
+                first.column(),
+            ),
             ErrorImpl::SerializeNestedEnum => {
                 f.write_str("serializing nested enums in YAML is not supported yet")
             }

--- a/dbt-serde_yaml/src/loader.rs
+++ b/dbt-serde_yaml/src/loader.rs
@@ -59,7 +59,7 @@ impl<'input> Loader<'input> {
         let first = self.document_count == 0;
         self.document_count += 1;
 
-        let mut anchors = BTreeMap::new();
+        let mut anchors: BTreeMap<_, (usize, Mark)> = BTreeMap::new();
         let mut document = Document {
             events: Vec::new(),
             error: None,
@@ -93,7 +93,7 @@ impl<'input> Loader<'input> {
                     return Some(document);
                 }
                 YamlEvent::Alias(alias) => match anchors.get(&alias) {
-                    Some(id) => Event::Alias(*id),
+                    Some((id, _)) => Event::Alias(*id),
                     None => {
                         document.error =
                             Some(error::new(ErrorImpl::UnknownAnchor(mark.into())).shared());
@@ -102,16 +102,36 @@ impl<'input> Loader<'input> {
                 },
                 YamlEvent::Scalar(mut scalar) => {
                     if let Some(anchor) = scalar.anchor.take() {
+                        if let Some((_, first_mark)) = anchors.get(&anchor) {
+                            document.error = Some(
+                                error::new(ErrorImpl::DuplicateAnchor {
+                                    first: (*first_mark).into(),
+                                    second: mark.into(),
+                                })
+                                .shared(),
+                            );
+                            return Some(document);
+                        }
                         let id = anchors.len();
-                        anchors.insert(anchor, id);
+                        anchors.insert(anchor, (id, mark));
                         document.aliases.insert(id, document.events.len());
                     }
                     Event::Scalar(scalar)
                 }
                 YamlEvent::SequenceStart(mut sequence_start) => {
                     if let Some(anchor) = sequence_start.anchor.take() {
+                        if let Some((_, first_mark)) = anchors.get(&anchor) {
+                            document.error = Some(
+                                error::new(ErrorImpl::DuplicateAnchor {
+                                    first: (*first_mark).into(),
+                                    second: mark.into(),
+                                })
+                                .shared(),
+                            );
+                            return Some(document);
+                        }
                         let id = anchors.len();
-                        anchors.insert(anchor, id);
+                        anchors.insert(anchor, (id, mark));
                         document.aliases.insert(id, document.events.len());
                     }
                     Event::SequenceStart(sequence_start)
@@ -119,8 +139,18 @@ impl<'input> Loader<'input> {
                 YamlEvent::SequenceEnd => Event::SequenceEnd,
                 YamlEvent::MappingStart(mut mapping_start) => {
                     if let Some(anchor) = mapping_start.anchor.take() {
+                        if let Some((_, first_mark)) = anchors.get(&anchor) {
+                            document.error = Some(
+                                error::new(ErrorImpl::DuplicateAnchor {
+                                    first: (*first_mark).into(),
+                                    second: mark.into(),
+                                })
+                                .shared(),
+                            );
+                            return Some(document);
+                        }
                         let id = anchors.len();
-                        anchors.insert(anchor, id);
+                        anchors.insert(anchor, (id, mark));
                         document.aliases.insert(id, document.events.len());
                     }
                     Event::MappingStart(mapping_start)

--- a/dbt-serde_yaml/tests/test_error.rs
+++ b/dbt-serde_yaml/tests/test_error.rs
@@ -108,6 +108,91 @@ fn test_unknown_anchor() {
 }
 
 #[test]
+fn test_duplicate_scalar_anchor() {
+    // Two scalar anchors with the same name: the second should be rejected.
+    let yaml = indoc! {"
+        first: &dup scalar_a
+        second: &dup scalar_b
+        result: *dup
+    "};
+    let expected = "found duplicate anchor; first occurrence at line 1 column 8 at line 2 column 9";
+    test_error::<Value>(yaml, expected);
+}
+
+#[test]
+fn test_duplicate_scalar_anchor_is_flagged() {
+    let yaml = indoc! {"
+        first: &dup scalar_a
+        second: &dup scalar_b
+        result: *dup
+    "};
+    let err = dbt_serde_yaml::from_str::<Value>(yaml).unwrap_err();
+    assert!(
+        err.is_duplicate_anchor(),
+        "expected is_duplicate_anchor() == true, got error: {err}"
+    );
+    // Second occurrence location is the error site.
+    let loc = err.location().expect("error should carry a location");
+    assert_eq!(loc.line(), 2, "second occurrence should be on line 2");
+}
+
+#[test]
+fn test_duplicate_sequence_anchor() {
+    // Two sequence anchors with the same name.
+    let yaml = indoc! {"
+        first: &dup
+          - a
+          - b
+        second: &dup
+          - c
+          - d
+    "};
+    let result = dbt_serde_yaml::from_str::<Value>(yaml);
+    let err = result.unwrap_err();
+    assert!(err.is_duplicate_anchor());
+    let msg = err.to_string();
+    assert!(
+        msg.contains("found duplicate anchor"),
+        "unexpected message: {msg}"
+    );
+    assert!(
+        msg.contains("first occurrence at line 1"),
+        "should mention first occurrence line, got: {msg}"
+    );
+}
+
+#[test]
+fn test_duplicate_mapping_anchor() {
+    // Two mapping anchors with the same name.
+    let yaml = indoc! {"
+        first: &dup
+          name: id
+        second: &dup
+          name: other_id
+    "};
+    let result = dbt_serde_yaml::from_str::<Value>(yaml);
+    let err = result.unwrap_err();
+    assert!(err.is_duplicate_anchor());
+}
+
+#[test]
+fn test_non_duplicate_anchor_is_not_flagged() {
+    // Sanity check: distinct anchor names must not trigger the error.
+    let yaml = indoc! {"
+        first: &anchor_a
+          - x
+        second: &anchor_b
+          - y
+        use_a: *anchor_a
+        use_b: *anchor_b
+    "};
+    assert!(
+        dbt_serde_yaml::from_str::<Value>(yaml).is_ok(),
+        "distinct anchors should parse without error"
+    );
+}
+
+#[test]
 fn test_ignored_unknown_anchor() {
     #[derive(Deserialize, Debug)]
     pub struct Wrapper {


### PR DESCRIPTION
Provide duplicate anchor detection logic and spans that can be used by dbt fusion to report errors.